### PR TITLE
Allow configuring number of clicks to edit

### DIFF
--- a/DoubleClickToEdit.plugin.js
+++ b/DoubleClickToEdit.plugin.js
@@ -21,7 +21,8 @@ class DoubleClickToEdit {
         if (window.ZLibrary) this.initialize();
 
         try {
-            document.addEventListener('click', e => this.handler(e));
+            this.cb = e=> this.handler(e)
+            document.addEventListener('click', this.cb);
         }
         catch(err) {
             console.error(this.getName(), "fatal error, plugin could not be started!", err);
@@ -59,7 +60,7 @@ class DoubleClickToEdit {
     }
 
     stop() {
-        document.removeEventListener('click', this.handler);
+        document.removeEventListener('click', this.cb);
     }
     
     handler(e) {


### PR DESCRIPTION
While using this plugin, i had the need to increase the number of consecutive clicks, as some times i had some issues, for example when selecting text, where the plugin immediately entered text edit mode. I had this locally and hardcoded to 4 consecutive clicks, now i tried making it configurable by adding a dedicated option in the settings tab of the plugin. By default the plugin will still check for double clicks, but now that's easiy changeable by simply changing the value in the text box.
(I'm not that much practical with js, so probably these changes might be "ugly", but that's the best i can do atm)