### PR TITLE
[Hide Channels] Require holding the ctrl key to toggle the channels list

### DIFF
--- a/Hide-Channels/HideChannels.plugin.js
+++ b/Hide-Channels/HideChannels.plugin.js
@@ -242,6 +242,8 @@ class HideChannels {
 
 		//Keydown event
 		useListener("keydown", e => {
+                        //Only toggle when the ctrl key is press (i.e. ctrl+h)
+                        if (!e.ctrlKey) return;
 			//Since we made this an object,
 			//we can make new propertire with `[]`
 			this.currentlyPressed[e.keyCode] = true;


### PR DESCRIPTION
As-is the H keybind causes the channel list to toggle every time I press the H key whilst typing into the chat box or whilst searching. I've simply added a ctrl key check to prevent that from happening, so instead of pressing H it will look for CTRL+H and the plugin will no longer clash with regular typing.