### PR TITLE
Fix the settings modal

### DIFF
--- a/Hide-Channels/HideChannels.plugin.js
+++ b/Hide-Channels/HideChannels.plugin.js
@@ -125,7 +125,10 @@ module.exports = class HideChannels {
 		//This also allows for a (delayed) call to retrieve a way to prompt a Form
 		if (!this.KeybindRecorder) {
 			this.KeybindRecorder = Webpack.getModule(m => m.prototype?.cleanUp); //BdApi.findModuleByDisplayName("KeybindRecorder");
-			this.FormItem = Webpack.getModule(Filters.byProps("Tags", "Sizes"));
+		}
+
+		if (!this.FormItem) {
+			this.FormItem = Object.assign(Webpack.getModule(Filters.byProps("Tags")), Webpack.getModule(Filters.byProps("Sizes")));
 		}
 
 		//Return our keybind settings wrapped in a form item


### PR DESCRIPTION
Right now the modal doesn't pop up, looks like it is due to this module not being found, this attempts to fix it. I haven't worked with webpack/BD plugins at all so I'm not certain but looking at `ZLibrary.DiscordModules.SettingsWrapper` which seems to grab the same `FormItem` webpack module... it seems like this fix should work. 