### PR TITLE
Add border-radius to parent element

### DIFF
--- a/Hide-Channels/HideChannels.plugin.js
+++ b/Hide-Channels/HideChannels.plugin.js
@@ -54,6 +54,7 @@ module.exports = class HideChannels {
 			//The sidebar to "minimize"/hide
 			this.sidebarClass = Webpack.getModule(Filters.byKeys("container", "base")).sidebar;
 			this.headerBarClass = Webpack.getModule(Filters.byKeys("chat", "title")).title;
+			this.baseClass = Webpack.getModule(Filters.byKeys("container", "base")).base;
 
 			//And the keybind
 			this.animation = this.checkKeybindLoad(Data.load(config.info.id, "animation")) ?? true;
@@ -340,6 +341,11 @@ module.exports = class HideChannels {
 /* Attached CSS to sidebar */
 .${config.constants.hideElementsName} {
     width: 0 !important;
+}
+
+/* Don't have square border at top left when channels are hidden */
+.${this.baseClass} {
+	border-radius: 8px 0 0 !important;
 }
 
 /* Set animations */


### PR DESCRIPTION
Throwing a border-radius on the parent element of channel list and the "main" container just allows the top left to not be square when the channel list is hidden

![image](https://github.com/Farcrada/DiscordPlugins/assets/933418/5376ea78-eb86-415d-91b0-add9d8611772)
