### PR TITLE
[Hide-Channels] Fix #156

### DIFF
--- a/Hide-Channels/HideChannels.plugin.js
+++ b/Hide-Channels/HideChannels.plugin.js
@@ -1,7 +1,7 @@
 /**
  * @name Hide Channels
  * @author Farcrada
- * @version 2.2.12
+ * @version 2.2.13
  * @description Hide channel list from view.
  *
  * @invite qH6UWCwfTu
@@ -329,7 +329,7 @@ module.exports = class HideChannels {
 }
 
 /* Attached CSS to sidebar */
-.${config.constants.hideElementsName} {
+html:not(.visual-refresh) .${config.constants.hideElementsName}.${config.constants.hideElementsName} {
     width: 0 !important;
 }
 


### PR DESCRIPTION
Fix for #156 (increase the specificify of the sidebar selector)

A Discord preparing for a visual refresh might be the culprit:
```
html:not(.visual-refresh) .sidebar_a4d4d9:not(.hidden_a4d4d9) {
    width: 240px!important
}
```