### PR TITLE
[Double Click To Edit]: update message selector fix #177

### DIFF
--- a/Double-click-to-edit/DoubleClickToEdit.plugin.js
+++ b/Double-click-to-edit/DoubleClickToEdit.plugin.js
@@ -220,8 +220,14 @@ module.exports = class DoubleClickToEdit {
 			return;
 
 		//Target the message
-		const messageDiv = e.target.closest('li > [class^=message]');
-
+		const messageDiv = e.target.closest(
+			'[data-list-item-id^="chat-messages"], ' +
+			'article[class*="message"], ' +
+			'div[class*="messageContainer"], ' +
+			'li > div[class*="message"], ' +
+			'li[class*="message"]'
+		);
+		
 		//If it finds nothing, null it.
 		if (!messageDiv)
 			return;


### PR DESCRIPTION
Hi. Changed the selector to a more universal one, because the current one not working after the latest updates of Discord 
#177

```md
## Discord Info
Stable 482285 (7fa90f1) Host 1.0.9219 x64 (73385) Windows 10 64-bit (10.0.19045)

## BetterDiscord
Stable 1.13.4
```